### PR TITLE
Hotfix/delete photos cloudinary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hanuman (6.4.0)
+    hanuman (6.4.1)
       actionmailer (~> 5.2.7)
       actionpack (~> 5.2.7)
       actionview (~> 5.2.7)

--- a/app/uploaders/hanuman/photo_uploader.rb
+++ b/app/uploaders/hanuman/photo_uploader.rb
@@ -20,7 +20,7 @@ module Hanuman
     # adding back delete photo on cloudinary when deleted on Wildnote now that we don't see issues with photos as much. Need this to decrease our storage and our
     # data integrity after a user cancels all data should be deleted
     def delete_remote?
-      false
+      true
     end
 
     # Choose what kind of storage to use for this uploader:

--- a/lib/hanuman/version.rb
+++ b/lib/hanuman/version.rb
@@ -1,3 +1,3 @@
 module Hanuman
-  VERSION = "6.4.1"
+  VERSION = "6.5.0"
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Re-enables remote deletion of Cloudinary assets, which is irreversible and could impact data retention if deletions are triggered unexpectedly. Otherwise changes are small and limited to version bumps.
> 
> **Overview**
> Re-enables Cloudinary cleanup by changing `Hanuman::PhotoUploader#delete_remote?` to return `true`, so removing an uploaded photo/record will also delete the corresponding remote asset.
> 
> Bumps the `hanuman` gem/version (lockfile and `lib/hanuman/version.rb`) to reflect the change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 483d02f943dede32b64f02487458474cc07c2701. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->